### PR TITLE
Changed order of IP address check for applications behind a proxy

### DIFF
--- a/BrRequest.php
+++ b/BrRequest.php
@@ -123,11 +123,11 @@ class BrRequest extends BrSingleton {
       $this->clientIP = br($_SERVER, 'HTTP_CLIENT_IP');
 
       if (!$this->clientIP || ($this->clientIP == 'unknown') || ($this->clientIP == '::1')) {
-        $this->clientIP = br($_SERVER, 'REMOTE_ADDR');
+        $this->clientIP = br($_SERVER, 'HTTP_X_FORWARDED_FOR');
       }
 
       if (!$this->clientIP || ($this->clientIP == 'unknown') || ($this->clientIP == '::1')) {
-        $this->clientIP = br($_SERVER, 'HTTP_X_FORWARDED_FOR');
+        $this->clientIP = br($_SERVER, 'REMOTE_ADDR');
       }
 
       if ($this->clientIP == '::1') {


### PR DESCRIPTION
To get the clients IP address when application is behind a proxy HTTP_X_FORWARDED_FOR needs to be checked before REMOTE_ADDR