### PR TITLE
Fixed Typo in Function getAdapters in class BrLog.

### DIFF
--- a/classes/BrLog.php
+++ b/classes/BrLog.php
@@ -53,7 +53,7 @@ class BrLog extends BrSingleton implements BrLoggable {
 
   public function getAdapters() {
 
-    return $this->adapter;
+    return $this->adapters;
 
   }
 


### PR DESCRIPTION
The function now returns the Adapters instead of null.